### PR TITLE
Adds support for when the motor thinks it's close enough to the target

### DIFF
--- a/lib/AM43Device.js
+++ b/lib/AM43Device.js
@@ -20,6 +20,8 @@ const StaticVariables = {
   AM43_RESPONSE_NACK: 0xa5,
 
   AM43_NOTIFY_POSITION: 0xa1,
+
+  POSITION_HISTORY_LENGTH: 5,
 }
 
 class AM43Device extends EventEmitter {
@@ -75,6 +77,8 @@ class AM43Device extends EventEmitter {
     this.targetPosition = null
     this.direction = 2 // 0: Down/Decreating, 1: Up/Increasing, 2: Stopped
     this.batteryPercentage = 50
+
+    this.positionHistory = []
   }
 
   debugLog(info) {
@@ -95,6 +99,13 @@ class AM43Device extends EventEmitter {
           percentage = parseInt(dataArray[5])
           this.debugLog(`Closed Percentage ${percentage}`)
           this.position = percentage
+
+          this.positionHistory.unshift(percentage)
+          this.positionHistory.length = Math.min(
+            StaticVariables.POSITION_HISTORY_LENGTH,
+            this.positionHistory.length
+          )
+
           this.emit("position", this.position)
           break
 
@@ -118,6 +129,13 @@ class AM43Device extends EventEmitter {
           percentage = parseInt(dataArray[4])
           this.debugLog(`Closed Percentage ${percentage}`)
           this.position = percentage
+
+          this.positionHistory.unshift(percentage)
+          this.positionHistory.length = Math.min(
+            StaticVariables.POSITION_HISTORY_LENGTH,
+            this.positionHistory.length
+          )
+
           this.emit("position", this.position)
           break
 
@@ -146,23 +164,9 @@ class AM43Device extends EventEmitter {
       if (this.targetPosition != null && this.position != null) {
         let direction = this.targetPosition < this.position ? 1 : 0
         let targetPosition = this.targetPosition
-        if (this.position == this.targetPosition) {
+        if (this.position == this.targetPosition || this.checkIfStopped()) {
           this.debugLog(
-            `Target position reached, position: ${this.position}, target: ${this.targetPosition}`
-          )
-          targetPosition = null
-        } else if (direction == 1 && this.targetPosition - this.position >= 1) {
-          this.debugLog(
-            `Target position reached, position: ${this.position}, target: ${
-              this.targetPosition
-            }, }, diff: ${this.targetPosition - this.position}`
-          )
-          targetPosition = null
-        } else if (direction == 0 && this.position - this.targetPosition >= 1) {
-          this.debugLog(
-            `Target position reached, position: ${this.position}, target: ${
-              this.targetPosition
-            }, diff: ${this.position - this.targetPosition}`
+            `Target position ${this.targetPosition} reached @ ${this.position}`
           )
           targetPosition = null
         }
@@ -252,6 +256,12 @@ class AM43Device extends EventEmitter {
         this.trackCurrentPosition()
       }
     }, 1000)
+  }
+
+  checkIfStopped() {
+    if (this.positionHistory.length < StaticVariables.POSITION_HISTORY_LENGTH)
+      return false
+    return this.positionHistory.every((v) => v === this.positionHistory[0])
   }
 
   async openAsync() {


### PR DESCRIPTION
- Tested on Pi3
- Solves issue where the AM43 motor thinks it's close enough to the target & stops causing the plugin to go into an infinite battery draining loop of position polling
- Might need to tweak the `POSITION_HISTORY_LENGTH` value if there's ever a window large enough that the percentage doesn't change within 5 updates
- First (& probably the most impactful) PR from my big experimental branch