### PR TITLE
Uses the "debug" package to output motor level debug logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #### This plugin is considered a work in progress
 
-# Homebridge AM43 Blinds 
+# Homebridge AM43 Blinds
 
 A homebridge plugin to control the AM43 based blind motors in HomeKit, these include the A-OK, [Zemismart](https://www.zemismart.com/products/diy-motorized-your-tranditional-roll-shade-which-with-bean-or-cord-chain-smart-home-automation-support-app-timer-remote-control), [Upndown](https://upndown.nl) and other blinds motors that use Bluetooth and the Blinds Engine app.
 
@@ -14,16 +14,16 @@ It also requires that the machine that hosts Homebridge has a Bluetooth radio th
 
 # Installation
 
-First make sure to setup the blinds using the blinds engine app, including the upper and lower limit. Kill the app after the setup is finished. Having the app open will make the blinds invisible to this plugin. 
+First make sure to setup the blinds using the blinds engine app, including the upper and lower limit. Kill the app after the setup is finished. Having the app open will make the blinds invisible to this plugin.
 
---- 
+---
 
 When running Homebridge on Debian, Ubuntu or Raspberry Pi you will first need to follow the following steps. macOS Users can skip these steps.
 
 1. Install bluetooth packages:
-`sudo apt-get install bluetooth bluez libbluetooth-dev libudev-dev`
+   `sudo apt-get install bluetooth bluez libbluetooth-dev libudev-dev`
 2. Give node/homebridge permission to use bluetooth:
-`sudo setcap cap_net_raw+eip $(eval readlink -f $(which node))`
+   `sudo setcap cap_net_raw+eip $(eval readlink -f $(which node))`
 
 Step 1 must be completed before you can continue with `npm install`.
 
@@ -49,6 +49,7 @@ After that you will need to enter the following details into the ~/.homebridge/c
      ]
  }
 ```
+
 Now start or restart homebridge and watch the logs. Homebridge will report that any AM43 motors that have been found will not be usable until added to the `allowed_devices` array. The log will also tell you the identifier of the motor to use. After adding the identifer the config should look a little something like this:
 
 ```JSON
@@ -58,17 +59,22 @@ Now start or restart homebridge and watch the logs. Homebridge will report that 
      }
 ```
 
-Please note that the identifiers in `allowed_devices` might be different depending on the platform you're on. However the should be the same between system reboots. 
+Please note that the identifiers in `allowed_devices` might be different depending on the platform you're on. However the should be the same between system reboots.
+
+# Debugging
+
+- running homebridge with `DEBUG=AM43` should cause motor-level debug logs to be output
 
 # Known Issues
+
 - [ ] The plugin is mostly untested. So far I've only tested it on a MacBook Pro 2019 and Raspberry Pi 3 Model B+
 - [ ] When setting up the motor you have to enter a password, however it doesn't seem to be used in the bluetooth calls I use in this plugin. This might become an issue later.
 - [ ] When running this plugin on Raspberry Pi it seems unable to re-connect to the blind after it was disconnected to preserve power. To work around this you can set `hap_interaction_timeout` in config.json to a value of 0. This will however cause the battery to drain faster.
 
 # Todo
-- [ ] Implement support for the Solar Panels light sensor, mine seems broken so I've ordered a new unit. 
+
+- [ ] Implement support for the Solar Panels light sensor, mine seems broken so I've ordered a new unit.
 
 # Thanks
 
-I have to thank [buxtronix/am43](https://github.com/buxtronix/am43), [binsentsu/am43-ctrl](https://github.com/binsentsu/am43-ctrl/) and [TheBazeman/A-OK-AM43-Blinds-Drive](https://github.com/TheBazeman/A-OK-AM43-Blinds-Drive) for the resources to get this plugin working. 
- 
+I have to thank [buxtronix/am43](https://github.com/buxtronix/am43), [binsentsu/am43-ctrl](https://github.com/binsentsu/am43-ctrl/) and [TheBazeman/A-OK-AM43-Blinds-Drive](https://github.com/TheBazeman/A-OK-AM43-Blinds-Drive) for the resources to get this plugin working.

--- a/lib/AM43Device.js
+++ b/lib/AM43Device.js
@@ -1,4 +1,5 @@
 const EventEmitter = require("events").EventEmitter
+const debug = require("debug")("AM43")
 
 const StaticVariables = {
   AM43_SERVICE_ID: "fe50",
@@ -78,7 +79,7 @@ class AM43Device extends EventEmitter {
   }
 
   debugLog(info) {
-    // console.log(info)
+    debug(`${this.description}: ${info}`)
   }
 
   setBlindsControlCharacteristic(characteristic) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       }
     },
     "@abandonware/noble": {
-      "version": "git+https://github.com/abandonware/noble.git#d8bf3061e3abd162dc6cb95d5335ebfdd89350e5",
+      "version": "git+https://github.com/abandonware/noble.git#2a8373c7b5d3bb5df68916be72f22b58fc8c4a61",
       "from": "git+https://github.com/abandonware/noble.git",
       "requires": {
         "@abandonware/bluetooth-hci-socket": "^0.5.3-5",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "license": "NIT",
   "dependencies": {
     "@abandonware/noble": "git+https://github.com/abandonware/noble.git",
+    "debug": "^4.2.0",
     "poll": "^1.0.1"
   },
   "prettier": {


### PR DESCRIPTION
- Think this is the recommended way to do it in Homebridge plugins, seems like the Hue plugin does it in a similar way to this
- Means the debug messages will be output (along with everything else) when `DEBUG=*` is given to homebridge, and when `DEBUG=AM43` is passed to homebridge 
- Homebridge-config-ui-x allows for setting the DEBUG property in the web interface
- Also prepends the logs with the description so it's easier to see which motor is reporting what


- Looks like the ReadMe was formatted on save, but the only new section is `# Debugging`